### PR TITLE
fix: prevent ally-target skills from buffing enemies

### DIFF
--- a/src/ai/nodes/UseSkillNode.js
+++ b/src/ai/nodes/UseSkillNode.js
@@ -43,6 +43,15 @@ class UseSkillNode extends Node {
             return NodeState.FAILURE;
         }
 
+        // 잘못된 대상에게 스킬을 사용하려는지 확인합니다.
+        if (
+            (modifiedSkill.targetType === 'ally' && skillTarget.team !== unit.team) ||
+            (modifiedSkill.targetType === 'enemy' && skillTarget.team === unit.team)
+        ) {
+            debugAIManager.logNodeResult(NodeState.FAILURE, '부적절한 대상에게 스킬 사용 시도');
+            return NodeState.FAILURE;
+        }
+
         // MBTI 스택 버프 시스템 제거로 관련 로직을 삭제합니다.
 
         debugSkillExecutionManager.logSkillExecution(unit, baseSkillData, modifiedSkill, instanceData.grade);

--- a/tests/adrenaline_targeting_test.js
+++ b/tests/adrenaline_targeting_test.js
@@ -1,0 +1,35 @@
+import assert from 'assert';
+
+// IndexedDB를 사용하지 않는 테스트 환경을 위한 스텁
+globalThis.indexedDB = { open: () => ({}) };
+
+// 필요한 모듈을 동적으로 불러옵니다.
+const { default: UseSkillNode } = await import('../src/ai/nodes/UseSkillNode.js');
+const { NodeState } = await import('../src/ai/nodes/Node.js');
+const { default: Blackboard } = await import('../src/ai/Blackboard.js');
+const { skillInventoryManager } = await import('../src/game/utils/SkillInventoryManager.js');
+const { tokenEngine } = await import('../src/game/utils/TokenEngine.js');
+
+// 최소한의 엔진 스텁을 준비합니다.
+const delayEngine = { hold: async () => {} };
+const vfxManager = { showSkillName() {}, showEffectName() {}, createDamageNumber() {} };
+const narrationEngine = { show() {} };
+
+const useSkillNode = new UseSkillNode({ delayEngine, vfxManager, narrationEngine });
+
+// 테스트용 유닛과 대상 유닛을 생성합니다.
+const caster = { uniqueId: 1, instanceName: 'Caster', team: 'A', finalStats: { hp: 100 }, currentHp: 100, sprite: {}, classPassive: null };
+const enemy = { uniqueId: 2, instanceName: 'Enemy', team: 'B', finalStats: { hp: 100 }, currentHp: 100, sprite: {} };
+
+// 토큰과 스킬을 설정합니다.
+tokenEngine.registerUnit(caster);
+const skillInstance = skillInventoryManager.addSkillById('adrenalineShot', 'NORMAL');
+
+const blackboard = new Blackboard();
+blackboard.set('skillTarget', enemy);
+blackboard.set('currentSkillInstanceId', skillInstance.instanceId);
+
+const result = await useSkillNode.evaluate(caster, blackboard);
+assert.strictEqual(result, NodeState.FAILURE, '아군 대상 스킬이 적에게 시전되어서는 안 됩니다.');
+
+console.log('Adrenaline targeting test passed.');


### PR DESCRIPTION
## Summary
- avoid casting ally-targeted skills on opposing units by validating teams
- add regression test for Adrenaline Shot targeting

## Testing
- `node tests/adrenaline_targeting_test.js`
- `node tests/status_effect_interaction_test.js`
- `node tests/medic_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689dd1682894832791a43de1198cc83b