### PR TITLE
feat: filter mbti by class

### DIFF
--- a/src/game/utils/ClassMBTIFilterEngine.js
+++ b/src/game/utils/ClassMBTIFilterEngine.js
@@ -1,0 +1,57 @@
+class ClassMBTIFilterEngine {
+    constructor() {
+        // 필터링 기능 활성화 여부 (기본값: 활성화)
+        this.enabled = true;
+        // 각 클래스별 허용 가능한 MBTI 풀
+        this.allowedMBTIs = {
+            nanomancer: ['INTP', 'INFP'],
+            medic: ['ISFJ', 'INFJ'],
+            warrior: ['ESTJ', 'ISTJ'],
+            gunner: ['ENFP', 'ENTP'],
+            mechanic: ['ENFJ', 'ENTP'],
+            sentinel: ['ISTJ', 'ISFJ'],
+            hacker: ['ISTP', 'INTP'],
+            ghost: ['ISFP', 'INFP'],
+            darkKnight: ['ESFP', 'ESTP'],
+            paladin: ['ESFJ', 'ENFJ'],
+            android: ['INFJ', 'ISFJ'],
+            plagueDoctor: ['INFP', 'INFJ'],
+            commander: ['ENTJ', 'ESTJ'],
+            clown: ['ENTP', 'ENFP'],
+            esper: ['INTJ', 'INFJ'],
+            flyingmen: ['ESTP', 'ENTP'],
+        };
+    }
+
+    /**
+     * 지정된 클래스에 맞는 MBTI 성향을 생성합니다.
+     * @param {string} classId - 용병의 클래스 ID
+     * @returns {object|null} - MBTI 성향 점수 객체 또는 null
+     */
+    generateFor(classId) {
+        const pool = this.allowedMBTIs[classId];
+        if (!this.enabled || !pool) return null;
+        const mbti = pool[Math.floor(Math.random() * pool.length)];
+        return this._mbtiStringToTraits(mbti);
+    }
+
+    /**
+     * MBTI 문자열을 점수 객체로 변환합니다.
+     * @param {string} mbti
+     * @returns {object}
+     */
+    _mbtiStringToTraits(mbti) {
+        return {
+            E: mbti[0] === 'E' ? 75 : 25,
+            I: mbti[0] === 'I' ? 75 : 25,
+            S: mbti[1] === 'S' ? 75 : 25,
+            N: mbti[1] === 'N' ? 75 : 25,
+            T: mbti[2] === 'T' ? 75 : 25,
+            F: mbti[2] === 'F' ? 75 : 25,
+            J: mbti[3] === 'J' ? 75 : 25,
+            P: mbti[3] === 'P' ? 75 : 25,
+        };
+    }
+}
+
+export const classMBTIFilterEngine = new ClassMBTIFilterEngine();

--- a/src/game/utils/MercenaryEngine.js
+++ b/src/game/utils/MercenaryEngine.js
@@ -9,6 +9,8 @@ import { attributeSpecializations } from '../data/attributeSpecializations.js';
 import { diceEngine } from './DiceEngine.js';
 // ✨ [추가] 아키타입 결정 엔진을 가져옵니다.
 import { archetypeAssignmentEngine } from './ArchetypeAssignmentEngine.js';
+// ✨ 클래스별 MBTI 필터링 엔진을 가져옵니다.
+import { classMBTIFilterEngine } from './ClassMBTIFilterEngine.js';
 
 /**
  * 용병의 생성, 저장, 관리를 전담하는 엔진 (싱글턴)
@@ -46,6 +48,9 @@ class MercenaryEngine {
         const randomName = this.mercenaryNames[Math.floor(Math.random() * this.mercenaryNames.length)];
         const uniqueId = uniqueIDManager.getNextId();
 
+        // ✨ 클래스에 따라 허용된 MBTI 성향을 우선적으로 부여합니다.
+        const filteredMbti = classMBTIFilterEngine.generateFor(baseMercenaryData.id);
+
         const newInstance = {
             ...baseMercenaryData,
             uniqueId,
@@ -56,7 +61,7 @@ class MercenaryEngine {
             // ✨ 모든 용병이 동일한 형태의 스킬 슬롯을 갖도록 초기화합니다.
             skillSlots: [null, null, null, null, null, null, null, null],
             // ✨ 각 용병은 고유한 MBTI 성향을 가집니다.
-            mbti: this._generateMBTI()
+            mbti: filteredMbti || this._generateMBTI()
         };
 
         // ✨ [핵심 추가] 용병 생성 직후 아키타입을 결정합니다.

--- a/tests/class_mbti_filter_test.js
+++ b/tests/class_mbti_filter_test.js
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { mercenaryEngine } from '../src/game/utils/MercenaryEngine.js';
+import { mercenaryData } from '../src/game/data/mercenaries.js';
+import { getMBTIString } from '../src/ai/mbtiProfiles.js';
+import { classMBTIFilterEngine } from '../src/game/utils/ClassMBTIFilterEngine.js';
+
+const originalRandom = Math.random;
+Math.random = () => 0; // 결과를 결정적으로 만듭니다.
+
+// 필터링이 활성화된 상태에서 생성된 메딕은 허용된 MBTI만 가져야 합니다.
+classMBTIFilterEngine.enabled = true;
+const medic = mercenaryEngine.hireMercenary(mercenaryData.medic);
+const medicMbti = getMBTIString(medic);
+assert(
+    classMBTIFilterEngine.allowedMBTIs.medic.includes(medicMbti),
+    `Filtered MBTI mismatch: ${medicMbti}`
+);
+
+// 필터링을 비활성화하면 어떤 MBTI든 받을 수 있습니다.
+classMBTIFilterEngine.enabled = false;
+const medic2 = mercenaryEngine.hireMercenary(mercenaryData.medic);
+const medicMbti2 = getMBTIString(medic2);
+assert(
+    !classMBTIFilterEngine.allowedMBTIs.medic.includes(medicMbti2),
+    'Filter disabling failed'
+);
+
+// 상태 원복
+Math.random = originalRandom;
+classMBTIFilterEngine.enabled = true;
+
+console.log('MBTI filtering test passed.');


### PR DESCRIPTION
## Summary
- ensure mercenaries receive MBTI traits that match their class
- allow toggling class MBTI filtering on/off (enabled by default)
- add regression test for MBTI filtering logic

## Testing
- `for f in tests/*_test.js; do node $f; done`
- `node tests/class_mbti_filter_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689dd600fad88327aaa03c6299662675