### PR TITLE
feat: switch mercenary AI to role-based profiles

### DIFF
--- a/src/ai/AIManager.js
+++ b/src/ai/AIManager.js
@@ -6,7 +6,6 @@ import { NodeState } from './nodes/Node.js';
 import { createMeleeAI } from './behaviors/MeleeAI.js';
 import { createRangedAI } from './behaviors/RangedAI.js';
 import { createHealerAI } from './behaviors/createHealerAI.js';
-import { createFlyingmanAI } from './behaviors/createFlyingmanAI.js';
 import { createINTJ_AI } from './behaviors/createINTJ_AI.js';
 // ✨ [신규] INTP AI import
 import { createINTP_AI } from './behaviors/createINTP_AI.js';
@@ -41,6 +40,9 @@ import { createENFJ_AI } from './behaviors/createENFJ_AI.js';
 // ✨ 용병 데이터에서 ai_archetype을 참조합니다.
 import { mercenaryData } from '../game/data/mercenaries.js';
 
+// MBTI 전투 AI 사용 여부 (기본값: 비활성화)
+const USE_MBTI_AI = false;
+
 /**
  * 게임 내 모든 AI 유닛을 관리하고, 각 유닛의 행동 트리를 실행합니다.
  */
@@ -69,7 +71,7 @@ class AIManager {
      */
     _createAIFromArchetype(unit) {
         const mbti = unit.mbti;
-        if (mbti) {
+        if (USE_MBTI_AI && mbti) {
             const mbtiString = (mbti.E > mbti.I ? 'E' : 'I') +
                                (mbti.S > mbti.N ? 'S' : 'N') +
                                (mbti.T > mbti.F ? 'T' : 'F') +
@@ -108,20 +110,12 @@ class AIManager {
         }
 
         const unitBaseData = mercenaryData[unit.id];
-        // ✨ [수정] 거너(gunner)가 ai_archetype을 사용하도록 수정
         if (unitBaseData && unitBaseData.ai_archetype) {
             switch (unitBaseData.ai_archetype) {
                 case 'ranged':
                     return createRangedAI(this.aiEngines);
                 case 'healer':
                     return createHealerAI(this.aiEngines);
-                case 'assassin':
-                    return createFlyingmanAI(this.aiEngines);
-                // ✨ [신규] 거너가 ENFP AI를 사용하도록 연결
-                case 'gunner':
-                    return createENFP_AI(this.aiEngines);
-                case 'enfj':
-                    return createENFJ_AI(this.aiEngines);
                 case 'melee':
                 default:
                     return createMeleeAI(this.aiEngines);
@@ -143,6 +137,7 @@ class AIManager {
             case 'gunner':
             case 'nanomancer':
             case 'esper':
+            case 'hacker':
                 fallbackAI = createRangedAI(this.aiEngines);
                 break;
 
@@ -154,17 +149,9 @@ class AIManager {
                 break;
 
             // --- 그 외 모든 근접/돌격 클래스 ---
-            case 'warrior':
-            case 'commander':
-            case 'android':
-            case 'sentinel':
-            case 'flyingmen':
-            case 'ghost':
-            case 'darkKnight':
-            case 'hacker':
-            case 'clown':
-            case 'paladin':
             default:
+                // warrior, commander, android, sentinel, flyingmen, ghost,
+                // darkKnight, clown, paladin 등
                 fallbackAI = createMeleeAI(this.aiEngines);
                 break;
         }

--- a/src/game/data/mercenaries.js
+++ b/src/game/data/mercenaries.js
@@ -35,8 +35,8 @@ export const mercenaryData = {
     gunner: {
         id: 'gunner',
         name: '거너',
-        // ✨ [수정] ai_archetype을 'gunner'로 명시하여 ENFP AI와 연결
-        ai_archetype: 'gunner',
+        // 전투 시에는 원거리 AI를 사용
+        ai_archetype: 'ranged',
         uiImage: 'assets/images/territory/gunner-ui.png',
         battleSprite: 'gunner',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -67,7 +67,8 @@ export const mercenaryData = {
     mechanic: {
         id: 'mechanic',
         name: '메카닉',
-        ai_archetype: 'enfj',
+        // 지원형 클래스이므로 힐러 AI 적용
+        ai_archetype: 'healer',
         uiImage: 'assets/images/unit/mechanic-ui.png',
         battleSprite: 'mechanic',
         sprites: {
@@ -157,7 +158,8 @@ export const mercenaryData = {
     flyingmen: {
         id: 'flyingmen',
         name: '플라잉맨',
-        ai_archetype: 'assassin',
+        // 돌격형이지만 기본 근접 AI 사용
+        ai_archetype: 'melee',
         uiImage: 'assets/images/unit/flyingmen-ui.png',
         battleSprite: 'flyingmen',
         // ✨ 모든 행동 스프라이트를 기본(idle)으로 통일
@@ -246,7 +248,8 @@ export const mercenaryData = {
     clown: {
         id: 'clown',
         name: '광대',
-        ai_archetype: 'assassin',
+        // 기동성은 높지만 근접 전투에 특화된 AI 사용
+        ai_archetype: 'melee',
         uiImage: 'assets/images/unit/clown-ui.png',
         battleSprite: 'clown',
         sprites: {
@@ -399,7 +402,8 @@ export const mercenaryData = {
     hacker: {
         id: 'hacker',
         name: '해커',
-        ai_archetype: 'melee', // 기본 AI는 근접 타입으로 설정
+        // 해커는 2타일 사거리로 원거리 AI와 더 잘 맞습니다.
+        ai_archetype: 'ranged',
         uiImage: 'assets/images/unit/hacker-ui.png',
         battleSprite: 'hacker',
         sprites: {
@@ -430,7 +434,8 @@ export const mercenaryData = {
     ghost: {
         id: 'ghost',
         name: '고스트',
-        ai_archetype: 'assassin',
+        // 은신형이지만 전투는 근접 AI로 처리
+        ai_archetype: 'melee',
         uiImage: 'assets/images/unit/ghost-ui.png',
         battleSprite: 'ghost',
         sprites: {


### PR DESCRIPTION
## Summary
- disable MBTI combat AI with toggle and favor role-based behaviors
- map each mercenary class to melee, ranged, or healer AI

## Testing
- `node tests/warrior_skill_integration_test.js`
- `node tests/gunner_skill_integration_test.js`
- `python3 -m http.server 8000 &`
- `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689ddbc5adec83278909a864e0b55c37