### PR TITLE
feat: add basic enemy AI for world map

### DIFF
--- a/src/game/ai/Blackboard.js
+++ b/src/game/ai/Blackboard.js
@@ -1,0 +1,24 @@
+/**
+ * 간단한 키-값 저장소로 AI 노드 간 정보를 공유합니다.
+ */
+export class Blackboard {
+    constructor() {
+        this.data = new Map();
+    }
+
+    /**
+     * @param {string} key
+     * @param {*} value
+     */
+    set(key, value) {
+        this.data.set(key, value);
+    }
+
+    /**
+     * @param {string} key
+     * @returns {*}
+     */
+    get(key) {
+        return this.data.get(key);
+    }
+}

--- a/src/game/ai/MoveTowardsPlayerNode.js
+++ b/src/game/ai/MoveTowardsPlayerNode.js
@@ -1,0 +1,44 @@
+import { Node, NodeState } from './Node.js';
+
+/**
+ * 플레이어 위치를 향해 한 칸 이동하는 행동 노드.
+ */
+export class MoveTowardsPlayerNode extends Node {
+    /**
+     * @param {Blackboard} blackboard
+     * @param {Phaser.Scene} scene
+     */
+    constructor(blackboard, scene) {
+        super(blackboard);
+        this.scene = scene;
+    }
+
+    /**
+     * @returns {NodeState}
+     */
+    execute() {
+        const player = this.blackboard.get('player');
+        const self = this.blackboard.get('self');
+
+        if (!player || !self) {
+            return NodeState.FAILURE;
+        }
+
+        const dx = player.tileX - self.tileX;
+        const dy = player.tileY - self.tileY;
+
+        let direction = null;
+        if (Math.abs(dx) > Math.abs(dy)) {
+            direction = dx > 0 ? 'right' : 'left';
+        } else if (Math.abs(dy) > 0) {
+            direction = dy > 0 ? 'down' : 'up';
+        }
+
+        if (direction) {
+            this.scene.moveEnemySquad(direction);
+            return NodeState.SUCCESS;
+        }
+
+        return NodeState.FAILURE;
+    }
+}

--- a/src/game/ai/Node.js
+++ b/src/game/ai/Node.js
@@ -1,0 +1,25 @@
+export const NodeState = {
+    SUCCESS: 'SUCCESS',
+    FAILURE: 'FAILURE',
+    RUNNING: 'RUNNING',
+};
+
+/**
+ * 모든 행동 노드의 기본 클래스.
+ */
+export class Node {
+    /**
+     * @param {Blackboard} blackboard 공유 정보 저장소
+     */
+    constructor(blackboard) {
+        this.blackboard = blackboard;
+    }
+
+    /**
+     * 노드가 수행할 로직을 정의합니다.
+     * @returns {NodeState}
+     */
+    execute() {
+        throw new Error('Execute method must be implemented in concrete nodes');
+    }
+}

--- a/src/game/ai/Sequence.js
+++ b/src/game/ai/Sequence.js
@@ -1,0 +1,28 @@
+import { Node, NodeState } from './Node.js';
+
+/**
+ * 자식 노드를 순차적으로 실행하는 시퀀스 노드.
+ */
+export class Sequence extends Node {
+    /**
+     * @param {Blackboard} blackboard
+     * @param {Node[]} children
+     */
+    constructor(blackboard, children) {
+        super(blackboard);
+        this.children = children;
+    }
+
+    /**
+     * @returns {NodeState}
+     */
+    execute() {
+        for (const child of this.children) {
+            const result = child.execute();
+            if (result !== NodeState.SUCCESS) {
+                return result;
+            }
+        }
+        return NodeState.SUCCESS;
+    }
+}

--- a/src/game/entities/EnemySquad.js
+++ b/src/game/entities/EnemySquad.js
@@ -1,0 +1,34 @@
+import * as Phaser from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+/**
+ * 적 부대를 표현하는 컨테이너.
+ * 플레이어 부대와 동일한 구성으로 좌우가 반전된 스프라이트를 사용합니다.
+ */
+export class EnemySquad extends Phaser.GameObjects.Container {
+    /**
+     * @param {Phaser.Scene} scene 부대가 추가될 씬
+     * @param {number} x 시작 x 좌표
+     * @param {number} y 시작 y 좌표
+     */
+    constructor(scene, x, y) {
+        super(scene, x, y);
+
+        // 1. 워리어, 거너, 메딕 스프라이트 생성 및 좌우반전
+        const warrior = scene.add.sprite(0, 10, 'warrior-entj').setScale(0.15).setFlipX(true);
+        const gunner = scene.add.sprite(-25, -10, 'gunner').setScale(0.1).setFlipX(true);
+        const medic = scene.add.sprite(25, -10, 'medic').setScale(0.1).setFlipX(true);
+
+        // 2. Y-맵핑 (depth) 적용
+        gunner.setDepth(1);
+        medic.setDepth(1);
+        warrior.setDepth(2);
+
+        // 3. 컨테이너에 스프라이트 추가
+        this.add([gunner, medic, warrior]);
+
+        // 4. 컨테이너를 씬에 추가하고 물리 활성화
+        scene.add.existing(this);
+        scene.physics.world.enable(this);
+        this.body.setSize(warrior.displayWidth, warrior.displayHeight);
+    }
+}

--- a/src/game/utils/WorldMapTurnEngine.js
+++ b/src/game/utils/WorldMapTurnEngine.js
@@ -1,10 +1,11 @@
 export class WorldMapTurnEngine {
     /**
      * @param {Phaser.Scene} scene 제어할 씬
+     * @param {import('../ai/Node.js').Node} [enemyAI] 적 AI 루트 노드
      */
-    constructor(scene) {
+    constructor(scene, enemyAI) {
         this.scene = scene;
-        this.hasMovedThisTurn = false;
+        this.enemyAI = enemyAI;
         this.isPlayerTurn = true;
         this.setupKeyboardControls();
     }
@@ -20,22 +21,23 @@ export class WorldMapTurnEngine {
     }
 
     /**
-     * 이동을 처리하고 턴을 넘깁니다.
+     * 이동을 처리하고 적 AI 턴을 실행합니다.
      * @param {'up' | 'down' | 'left' | 'right'} direction
      */
     handleMove(direction) {
-        if (!this.isPlayerTurn || this.hasMovedThisTurn) return;
+        if (!this.isPlayerTurn) return;
 
         this.isPlayerTurn = false;
-        this.hasMovedThisTurn = true;
 
-        // WorldMapScene의 moveSquad 메서드를 호출합니다.
+        // 플레이어 이동
         this.scene.moveSquad(direction);
 
-        this.scene.time.delayedCall(200, () => {
+        // 적 AI 행동 수행 후 턴 반환
+        this.scene.time.delayedCall(300, () => {
+            if (this.enemyAI) {
+                this.enemyAI.execute();
+            }
             this.isPlayerTurn = true;
-            this.hasMovedThisTurn = false;
         });
     }
 }
-


### PR DESCRIPTION
## Summary
- add mirrored EnemySquad container for world map battles
- implement minimal behavior-tree AI (blackboard, sequence, movement) for enemy squads
- update world map to spawn enemy squad and alternate turns between player and AI

## Testing
- `for f in tests/*_test.js; do node $f; done`
- `node tests/movement_stat_test.js 2>&1 | tail -n 20`
- `python3 -m http.server 8000 &` (then `curl http://localhost:8000/debug.html | head -n 20`)


------
https://chatgpt.com/codex/tasks/task_e_689e1c96371c8327bac6d0f0306e5073