### PR TITLE
feat: add unit stat handling and health bars

### DIFF
--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -8,6 +8,9 @@ import { EnemySquad } from '../entities/EnemySquad.js';
 import { Blackboard } from '../ai/Blackboard.js';
 import { Sequence } from '../ai/Sequence.js';
 import { MoveTowardsPlayerNode } from '../ai/MoveTowardsPlayerNode.js';
+import { mercenaryData } from '../data/mercenaries.js';
+import { statEngine } from '../utils/StatEngine.js';
+import { HealthBar } from '../ui/HealthBar.js';
 
 export class WorldMapScene extends Scene {
     constructor() {
@@ -53,6 +56,36 @@ export class WorldMapScene extends Scene {
         this.enemySquad.tileX = enemyStartTileX;
         this.enemySquad.tileY = enemyStartTileY;
 
+        // === 스탯 설정 로직 추가 시작 ===
+        const plagueDoctorData = mercenaryData.plagueDoctor;
+        this.squad.commander = {
+            ...plagueDoctorData,
+            finalStats: statEngine.calculateStats(plagueDoctorData, plagueDoctorData.baseStats)
+        };
+
+        const warriorData = mercenaryData.warrior;
+        this.enemySquad.warrior = {
+            ...warriorData,
+            finalStats: statEngine.calculateStats(warriorData, warriorData.baseStats)
+        };
+
+        const gunnerData = mercenaryData.gunner;
+        this.squad.gunnerStats = statEngine.calculateStats(gunnerData, gunnerData.baseStats);
+        this.enemySquad.gunnerStats = this.squad.gunnerStats;
+
+        const medicData = mercenaryData.medic;
+        this.squad.medicStats = statEngine.calculateStats(medicData, medicData.baseStats);
+        this.enemySquad.medicStats = this.squad.medicStats;
+
+        this.squad.commander.currentHp = this.squad.commander.finalStats.hp;
+        this.enemySquad.warrior.currentHp = this.enemySquad.warrior.finalStats.hp;
+        // === 스탯 설정 로직 추가 종료 ===
+
+        // === 체력바 생성 로직 추가 시작 ===
+        this.playerHealthBar = new HealthBar(this, this.squad.x - 30, this.squad.y - 40);
+        this.enemyHealthBar = new HealthBar(this, this.enemySquad.x - 30, this.enemySquad.y - 40);
+        // === 체력바 생성 로직 추가 종료 ===
+
         // AI 설정
         const blackboard = new Blackboard();
         blackboard.set('player', this.squad);
@@ -78,6 +111,20 @@ export class WorldMapScene extends Scene {
                 territoryContainer.style.display = 'block';
             }
         });
+    }
+
+    update() {
+        if (this.squad && this.playerHealthBar) {
+            this.playerHealthBar.setPosition(this.squad.x - 30, this.squad.y - 50);
+            const playerHpPercent = (this.squad.commander.currentHp / this.squad.commander.finalStats.hp) * 100;
+            this.playerHealthBar.setHealth(playerHpPercent);
+        }
+
+        if (this.enemySquad && this.enemyHealthBar) {
+            this.enemyHealthBar.setPosition(this.enemySquad.x - 30, this.enemySquad.y - 50);
+            const enemyHpPercent = (this.enemySquad.warrior.currentHp / this.enemySquad.warrior.finalStats.hp) * 100;
+            this.enemyHealthBar.setHealth(enemyHpPercent);
+        }
     }
 
     // 플레이어 부대 이동 메서드

--- a/src/game/ui/HealthBar.js
+++ b/src/game/ui/HealthBar.js
@@ -1,0 +1,63 @@
+import { Scene } from 'https://cdn.jsdelivr.net/npm/phaser@3.90.0/dist/phaser.esm.js';
+
+export class HealthBar {
+    /**
+     * @param {Phaser.Scene} scene
+     * @param {number} x
+     * @param {number} y
+     * @param {number} width
+     * @param {number} height
+     */
+    constructor(scene, x, y, width = 60, height = 8) {
+        this.bar = scene.add.graphics();
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+        this.value = 100;
+
+        this.draw();
+        
+        scene.add.existing(this.bar);
+    }
+
+    /**
+     * @param {number} amount
+     */
+    setHealth(amount) {
+        this.value = Math.max(0, Math.min(100, amount));
+        this.draw();
+    }
+    
+    setPosition(x, y) {
+        this.x = x;
+        this.y = y;
+        this.draw();
+    }
+
+    draw() {
+        this.bar.clear();
+
+        // 배경
+        this.bar.fillStyle(0x000000);
+        this.bar.fillRect(this.x, this.y, this.width, this.height);
+
+        // 체력
+        this.bar.fillStyle(0xffffff);
+        this.bar.fillRect(this.x + 2, this.y + 2, this.width - 4, this.height - 4);
+
+        if (this.value < 30) {
+            this.bar.fillStyle(0xff0000);
+        } else {
+            this.bar.fillStyle(0x00ff00);
+        }
+
+        const d = Math.floor((this.width - 4) * (this.value / 100));
+
+        this.bar.fillRect(this.x + 2, this.y + 2, d, this.height - 4);
+    }
+    
+    destroy() {
+        this.bar.destroy();
+    }
+}


### PR DESCRIPTION
## Summary
- compute squad and enemy unit stats in world map
- add reusable health bar UI and wire to player and enemy squads

## Testing
- `node tests/movement_stat_test.js`
- `python3 -m http.server 8000 &` `curl http://localhost:8000/debug.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689e2117fd188327a4be71d0c61cb0ad