### PR TITLE
feat: add unit-specific actions and health bar handling

### DIFF
--- a/src/game/engine/AttackEngine.js
+++ b/src/game/engine/AttackEngine.js
@@ -10,17 +10,41 @@ export const attackEngine = {
      * @param {object} target - 공격받는 유닛 객체
      */
     performAttack: (attacker, target) => {
-        // 기본 대미지는 공격자의 공격력(atk) 스탯을 따릅니다.
+        // 공격 대상이 이미 쓰러졌다면 아무것도 하지 않음
+        if (target.currentHp <= 0) {
+            console.log(`${target.name}은(는) 이미 쓰러져 있습니다.`);
+            return;
+        }
+
         const damage = attacker.finalStats.atk;
-        
-        // 대상의 현재 체력을 감소시킵니다.
         target.currentHp -= damage;
 
         console.log(`%c${attacker.name}이(가) ${target.name}에게 ${damage}의 피해를 입혔습니다! (남은 체력: ${target.currentHp})`, "color: orange");
 
-        // 체력이 0 미만으로 내려가지 않도록 보정합니다.
         if (target.currentHp < 0) {
             target.currentHp = 0;
         }
+    },
+
+    /**
+     * 대상을 치유합니다.
+     * @param {object} healer - 치유하는 유닛 객체 (메딕)
+     * @param {object} target - 치유받는 유닛 객체
+     */
+    performHeal: (healer, target) => {
+        // 치유 대상이 이미 쓰러졌다면 아무것도 하지 않음
+        if (target.currentHp <= 0) return;
+
+        // 치유량은 메딕의 지혜(wisdom) 스탯을 따릅니다.
+        const healAmount = healer.finalStats.wisdom;
+        target.currentHp += healAmount;
+
+        // 최대 체력을 초과하지 않도록 보정합니다.
+        const maxHp = target.finalStats.hp;
+        if (target.currentHp > maxHp) {
+            target.currentHp = maxHp;
+        }
+
+        console.log(`%c${healer.name}이(가) ${target.name}을(를) ${healAmount}만큼 치유했습니다! (현재 체력: ${target.currentHp})`, "color: green");
     }
 };

--- a/src/game/engine/CombatManager.js
+++ b/src/game/engine/CombatManager.js
@@ -21,54 +21,78 @@ export class CombatManager {
     initiateCombatTurn(playerSquad, enemySquad) {
         console.log("%c 전투 시작!", "color: red; font-size: 16px;");
 
-        // 1. 모든 유닛 목록 생성
+        // 1. 모든 유닛 목록 생성 및 팀 지정
         const playerUnits = Object.values(playerSquad.units);
-        playerUnits.forEach(u => u.team = 'player'); // 팀 구분용 속성 추가
+        playerUnits.forEach(u => u.team = 'player');
 
         const enemyUnits = Object.values(enemySquad.units);
         enemyUnits.forEach(u => u.team = 'enemy');
 
         const allUnits = [...playerUnits, ...enemyUnits];
-
-        // 2. 'weight' 스탯을 기준으로 행동 순서 정렬 (가벼운 유닛이 먼저)
         allUnits.sort((a, b) => a.finalStats.weight - b.finalStats.weight);
 
         console.log("이번 턴 행동 순서:", allUnits.map(u => `${u.name} (무게: ${u.finalStats.weight})`));
 
-        // 3. 정해진 순서대로 공격 수행
+        // 각 부대의 리더와 후방 유닛을 정의
         const playerLeader = playerSquad.units.commander;
         const enemyLeader = enemySquad.units.warrior;
+        const playerBackline = [playerSquad.units.gunner, playerSquad.units.medic];
+        const enemyBackline = [enemySquad.units.gunner, enemySquad.units.medic];
 
-        allUnits.forEach((attacker, index) => {
-            // 각 유닛이 순차적으로 공격하는 것처럼 보이도록 시간차를 둡니다.
-            this.scene.time.delayedCall(300 * index, () => {
-                // 리더 유닛 중 하나라도 쓰러졌으면 전투를 중단합니다.
-                if (playerLeader.currentHp <= 0 || enemyLeader.currentHp <= 0) {
-                    return;
+        allUnits.forEach((unit, index) => {
+            this.scene.time.delayedCall(400 * index, () => {
+                if (playerLeader.currentHp <= 0 || enemyLeader.currentHp <= 0) return;
+
+                // === 유닛 역할에 따른 행동 분기 ===
+                switch (unit.name) {
+                    case 'Medic':
+                        // 메딕: 소속 팀의 리더를 치유
+                        const leaderToHeal = unit.team === 'player' ? playerLeader : enemyLeader;
+                        attackEngine.performHeal(unit, leaderToHeal);
+                        break;
+
+                    case 'Gunner':
+                        // 거너: 50% 확률로 적 리더 또는 적 후방 유닛 공격
+                        const targetLeader = unit.team === 'player' ? enemyLeader : playerLeader;
+                        const targetBackline = unit.team === 'player' ? enemyBackline : playerBackline;
+                        let target;
+
+                        if (Math.random() < 0.5) {
+                            const aliveBackliners = targetBackline.filter(u => u.currentHp > 0);
+                            if (aliveBackliners.length > 0) {
+                                target = aliveBackliners[Math.floor(Math.random() * aliveBackliners.length)];
+                            } else {
+                                target = targetLeader;
+                            }
+                        } else {
+                            target = targetLeader;
+                        }
+                        attackEngine.performAttack(unit, target);
+                        break;
+
+                    default:
+                        // 지휘관(역병 의사, 워리어): 서로의 리더를 공격
+                        const opponentLeader = unit.team === 'player' ? enemyLeader : playerLeader;
+                        attackEngine.performAttack(unit, opponentLeader);
+                        break;
                 }
-
-                // 공격 대상 지정 (아군 -> 적 리더, 적군 -> 아군 리더)
-                const target = attacker.team === 'player' ? enemyLeader : playerLeader;
-                attackEngine.performAttack(attacker, target);
             });
         });
-        
-        // 모든 공격이 끝난 후 전투 상태를 해제합니다.
-        const totalTurnTime = 300 * allUnits.length;
+
+        const totalTurnTime = 400 * allUnits.length;
         this.scene.time.delayedCall(totalTurnTime + 500, () => {
             console.log("%c 전투 턴 종료.", "color: blue;");
-            
+
             if (playerLeader.currentHp <= 0) {
                 console.log("아군 패배!");
                 this.scene.scene.start('GameOver');
             } else if (enemyLeader.currentHp <= 0) {
-                console.log("적군 패배!");
-                // 여기서 승리 로직을 추가할 수 있습니다. (예: 적 부대 제거)
+                console.log("적군 승리!");
                 enemySquad.destroy();
-                enemySquad.healthBar.destroy();
+                // 체력바가 부대 객체에 연결되어 있지 않으므로, 씬에서 직접 제거
+                this.scene.enemyHealthBar.destroy();
             }
-            
-            // 전투가 끝났으므로 다시 움직일 수 있습니다.
+
             this.scene.isBattling = false;
         });
     }

--- a/src/game/scenes/WorldMapScene.js
+++ b/src/game/scenes/WorldMapScene.js
@@ -23,6 +23,8 @@ export class WorldMapScene extends Scene {
         this.turnEngine = null;
         this.ai = null;
         this.isBattling = false;
+        this.playerHealthBar = null;
+        this.enemyHealthBar = null;
     }
 
     create() {
@@ -74,9 +76,9 @@ export class WorldMapScene extends Scene {
             medic: this.createUnitData(mercenaryData.medic)
         };
         
-        // === 체력바 생성 로직 수정: 부대 객체에 체력바를 직접 연결 ===
-        this.squad.healthBar = new HealthBar(this, this.squad.x - 30, this.squad.y - 40);
-        this.enemySquad.healthBar = new HealthBar(this, this.enemySquad.x - 30, this.enemySquad.y - 40);
+        // 체력바 생성
+        this.playerHealthBar = new HealthBar(this, this.squad.x - 30, this.squad.y - 40);
+        this.enemyHealthBar = new HealthBar(this, this.enemySquad.x - 30, this.enemySquad.y - 40);
 
         // 전투 관리자 생성
         this.combatManager = new CombatManager(this);
@@ -153,16 +155,20 @@ export class WorldMapScene extends Scene {
         }
         
         // 체력바 위치 및 값 업데이트
-        if (this.squad.active) {
-            this.squad.healthBar.setPosition(this.squad.x - 30, this.squad.y - 50);
+        if (this.squad && this.playerHealthBar) {
+            this.playerHealthBar.setPosition(this.squad.x - 30, this.squad.y - 50);
             const playerHpPercent = (this.squad.units.commander.currentHp / this.squad.units.commander.finalStats.hp) * 100;
-            this.squad.healthBar.setHealth(playerHpPercent);
+            this.playerHealthBar.setHealth(playerHpPercent);
         }
-        
-        if (this.enemySquad.active) {
-            this.enemySquad.healthBar.setPosition(this.enemySquad.x - 30, this.enemySquad.y - 50);
+
+        if (this.enemySquad && this.enemyHealthBar && this.enemySquad.active) {
+            this.enemyHealthBar.setPosition(this.enemySquad.x - 30, this.enemySquad.y - 50);
             const enemyHpPercent = (this.enemySquad.units.warrior.currentHp / this.enemySquad.units.warrior.finalStats.hp) * 100;
-            this.enemySquad.healthBar.setHealth(enemyHpPercent);
+            this.enemyHealthBar.setHealth(enemyHpPercent);
+        } else if (this.enemyHealthBar && !this.enemySquad.active) {
+            // 적이 비활성화(파괴)되면 체력바도 숨김
+            this.enemyHealthBar.destroy();
+            this.enemyHealthBar = null;
         }
     }
 


### PR DESCRIPTION
## Summary
- expand attack engine with healing and alive checks
- add class-specific combat logic and clean up enemy health bar on defeat
- keep world health bars on scene for easier lifecycle management

## Testing
- `npm test` *(fails: Missing script "test")*
- `python3 -m http.server 8000 &` and `curl http://localhost:8000/debug.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689e246068948327b4440bf5e91a2eca